### PR TITLE
Fix CL error with remove-if

### DIFF
--- a/ligature.el
+++ b/ligature.el
@@ -122,6 +122,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defvar ligature-composition-table nil
   "Alist of ligature compositions.
 
@@ -192,7 +194,7 @@ The changes are then made local to the current buffer."
             (rules (cdr ligature-table))) ; alist of rules mapping a character to a regexp.
         ;; If `mode' is t we always apply the rules, regardless of
         ;; whether `derived-mode-p' matches or not.
-        (when (or (booleanp modes) (remove-if 'null (mapcar 'derived-mode-p
+        (when (or (booleanp modes) (cl-remove-if 'null (mapcar 'derived-mode-p
                                                             (if (listp modes)
                                                                 modes
                                                               (list modes)))))


### PR DESCRIPTION
This prevent this package to load properly if cl.el is not required
explicitely by user.

remove-if comes from cl.el which is deprecated in emacs-27, use cl-remove-if
instead and require cl-lib.