### PR TITLE
Fix Cascadia Code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ you may find it won't work 100% if you use a different one.
                                          "<$" "<=" "<>" "<-" "<<" "<+" "</" "#{" "#[" "#:" "#=" "#!"
                                          "##" "#(" "#?" "#_" "%%" ".=" ".-" ".." ".?" "+>" "++" "?:"
                                          "?=" "?." "??" ";;" "/*" "/=" "/>" "//" "__" "~~" "(*" "*)"
-                                         "\\" "://"))
+                                         "\\\\" "://"))
     ;; Enables ligature checks globally in all buffers. You can also do it
     ;; per mode with `ligature-mode'.
     (global-ligature-mode t))


### PR DESCRIPTION
Since `"\\"` after quoting becomes `"\"`, we need to make it `"\\\\"`.