### PR TITLE
Fix missing apostrophe in JetBrains Mono config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ you may find it won't work 100% if you use a different one.
     :load-path "path-to-ligature-repo"
     :config
     ;; Enable all JetBrains Mono ligatures in programming modes
-    (ligature-set-ligatures prog-mode '("-|" "-~" "---" "-<<" "-<" "--" "->" "->>" "-->" "///" "/=" "/=="
+    (ligature-set-ligatures 'prog-mode '("-|" "-~" "---" "-<<" "-<" "--" "->" "->>" "-->" "///" "/=" "/=="
                                         "/>" "//" "/*" "*>" "***" "*/" "<-" "<<-" "<=>" "<=" "<|" "<||"
                                         "<|||" "<|>" "<:" "<>" "<-<" "<<<" "<==" "<<=" "<=<" "<==>" "<-|"
                                         "<<" "<~>" "<=|" "<~~" "<~" "<$>" "<$" "<+>" "<+" "</>" "</" "<*"


### PR DESCRIPTION
Some apostrophe was missing inside the config for the JetBrains Mono font.