### PR TITLE
Add missing backslash escape character in commentary example

### DIFF
--- a/ligature.el
+++ b/ligature.el
@@ -84,7 +84,7 @@
 ;;                                        "<$" "<=" "<>" "<-" "<<" "<+" "</" "#{" "#[" "#:" "#=" "#!"
 ;;                                        "##" "#(" "#?" "#_" "%%" ".=" ".-" ".." ".?" "+>" "++" "?:"
 ;;                                        "?=" "?." "??" ";;" "/*" "/=" "/>" "//" "__" "~~" "(*" "*)"
-;;                                        "\\" "://"))
+;;                                        "\\\\" "://"))
 ;;   ;; Enables ligature checks globally in all buffers.  You can also do it
 ;;   ;; per mode with `ligature-mode'.
 ;;   (global-ligature-mode t))


### PR DESCRIPTION
Fixes "Ligature ‘\\’ must be 2 characters or longer" error.